### PR TITLE
Fix authenticator version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 # install eksctl, IAM authenticator, kubectl, and jq:
 RUN yum -y install shadow-utils && \
-    curl https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator -o aws-iam-authenticator  && \
+    curl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator -o aws-iam-authenticator  && \
     chmod +x ./aws-iam-authenticator && \
     mv ./aws-iam-authenticator /usr/local/bin && \
     curl --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ kind: ClusterConfig
 metadata:
   name: $CLUSTER_NAME
   region: $TARGET_REGION
-  version: '1.16'
+  version: '1.21'
 iam:
   withOIDC: true
 fargateProfiles:


### PR DESCRIPTION
*Issue #, if available:*
#2 
*Description of changes:*
A very minimal update to make use of the latest authenticator version as the version currently used (1.16) is no longer accepted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
